### PR TITLE
mark-glance-endpoints-as-not-implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ The following list shows methods available and missing:
 - [x] Get room message
 - [x] View room history
 - [x] View recent room history
-- [x] Get glance
-- [x] Create glance
-- [x] Delete glance
+- [ ] Get glance
+- [ ] Create glance
+- [ ] Delete glance
 - [x] Invite user
 - [x] Add member
 - [x] Remove member

--- a/src/API/RoomAPI.php
+++ b/src/API/RoomAPI.php
@@ -215,7 +215,7 @@ class RoomAPI extends API {
      * @param mixed $roomid id or name
      */
     public function getGlance($roomid) {
-
+        // TODO: method stub
     }
 
     /**
@@ -223,7 +223,7 @@ class RoomAPI extends API {
      * @param type $roomid
      */
     public function createGlance($roomid) {
-
+        // TODO: method stub
     }
 
     /**
@@ -231,7 +231,7 @@ class RoomAPI extends API {
      * @param mixed $roomid id or name
      */
     public function deleteGlance($roomid) {
-
+        // TODO: method stub
     }
 
     /**


### PR DESCRIPTION
Marked glance endpoints as not implemented, and added TODO method stub comments.

Fixes #1 